### PR TITLE
Show user profiles in the user page header

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -616,7 +616,7 @@ class Client {
             return;
         }
         const mediaUrl = this.serverUrl.slice(0, -1 * "/client".length);
-        return `${mediaUrl}/media/r0/thumbnail/${mxcUri.split("mxc://")[1]}?method=${method}&width=${width}&height=${height}`;
+        return `${mediaUrl}/media/r0/thumbnail/${mxcUri.split("mxc://")[1]}?method=${encodeURIComponent(method)}&width=${encodeURIComponent(width)}&height=${encodeURIComponent(height)}`;
     }
 
     async fetchJson(fullUrl, fetchParams) {

--- a/src/Client.js
+++ b/src/Client.js
@@ -116,6 +116,19 @@ class Client {
         this.saveAuthState();
     }
 
+    async getProfile(userId) {
+        const data = await this.fetchJson(
+            `${this.serverUrl}/r0/profile/${encodeURIComponent(
+                userId
+            )}`,
+            {
+                method: "GET",
+                headers: { Authorization: `Bearer ${this.accessToken}` },
+            }
+        );
+        return data;
+    }
+
     async sendMessage(roomId, content) {
         const txnId = Date.now();
         const data = await this.fetchJson(
@@ -593,6 +606,17 @@ class Client {
         }
         const mediaUrl = this.serverUrl.slice(0, -1 * "/client".length);
         return mediaUrl + "/media/r0/download/" + mxcUri.split("mxc://")[1];
+    }
+
+    thumbnailLink(mxcUri, method, width, height) {
+        if (!mxcUri) {
+            return;
+        }
+        if (mxcUri.indexOf("mxc://") !== 0) {
+            return;
+        }
+        const mediaUrl = this.serverUrl.slice(0, -1 * "/client".length);
+        return `${mediaUrl}/media/r0/thumbnail/${mxcUri.split("mxc://")[1]}?method=${method}&width=${width}&height=${height}`;
     }
 
     async fetchJson(fullUrl, fetchParams) {

--- a/src/TimelinePage.css
+++ b/src/TimelinePage.css
@@ -23,7 +23,7 @@
     /* Body SemiBold */
     font-family: Inter;
     font-style: normal;
-    font-weight: 600;
+    font-weight: 400;
     font-size: 15px;
     line-height: 18px;
 

--- a/src/UserPage.css
+++ b/src/UserPage.css
@@ -4,7 +4,9 @@
 }
 
 .UserPageHeader{
+    line-height: 18px;
     padding-bottom: 15px;
+    font-family: Inter;
 }
 
 .UserPage{
@@ -24,13 +26,28 @@
     border-bottom-right-radius: 12px;
 }
 
-.userName{
+.displayName{
     /* Body SemiBold */
-    font-family: Inter;
     font-style: normal;
     font-weight: 600;
     font-size: 15px;
     line-height: 18px;
+
+    /* Light / Primary content */
+    color: #17191C;
+
+    margin-bottom: 8px;
+
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.userName{
+    /* Body SemiBold */
+    font-style: normal;
+    font-weight: 400;
+    font-size: 14px;
 
     /* Light / Primary content */
     color: #17191C;
@@ -71,4 +88,9 @@
 .emptyList {
     padding: 8px;
     text-align: center;
+}
+
+.userAvatar{
+    float: left;
+    margin-right: 1em;
 }

--- a/src/UserPage.js
+++ b/src/UserPage.js
@@ -20,6 +20,7 @@ class UserPage extends React.Component {
             timeline: [],
             isMe: props.userId === props.client.userId,
             roomId: null,
+            userProfile: null,
         };
     }
 
@@ -50,6 +51,17 @@ class UserPage extends React.Component {
         let roomId;
         try {
             roomId = await this.props.client.followUser(this.props.userId);
+            try {
+                const userProfile = await this.props.client.getProfile(this.props.userId);
+                this.setState({
+                    userProfile,
+                });
+                if (userProfile.avatar_url) {
+                    userProfile.avatar_url = this.props.client.thumbnailLink(userProfile.avatar_url, "scale", 64, 64);
+                }
+            } catch (ex) {
+                console.warn(`Failed to fetch user profile, might not be set yet`, ex);
+            }
 
             let timeline = await this.props.client.getTimeline(roomId);
             console.log("Set timeline with ", timeline.length, " items");
@@ -184,6 +196,8 @@ class UserPage extends React.Component {
         if (!this.props.client.isGuest) {
             userPageHeader = (
                 <div className="UserPageHeader">
+                    { this.state.userProfile?.avatar_url && <img alt="User avatar" className="userAvatar" src={this.state.userProfile?.avatar_url}></img>}
+                    { this.state.userProfile?.displayname && <div className="displayName">{this.state.userProfile?.displayname}</div> }
                     <div className="userName">{this.props.userId}</div>
                     {inputMessage}
                     {errBlock}


### PR DESCRIPTION
This is to alleviate an issue where bridges will show ugly looking userIds in order to ensure uniqueness, and so the UI should prefer to highlight the displayname / profile where possible.

I don't know if we were planning to use the room name / room avatar as the true source instead of the profile of the user, so feel free to ask and I can change that.