### PR TITLE
Show displayname on message

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -133,8 +133,6 @@ class Client {
         this.userProfileCache.set(userId, data);
         return data;
     }
-        return data;
-    }
 
     async sendMessage(roomId, content) {
         const txnId = Date.now();

--- a/src/Client.js
+++ b/src/Client.js
@@ -7,6 +7,7 @@ class Client {
 
     constructor(storage) {
         this.joinedRooms = new Map(); // room alias -> room ID
+        this.userProfileCache = new Map(); // user_id -> {display_name; avatar;}
         if (!storage) {
             return;
         }
@@ -117,6 +118,11 @@ class Client {
     }
 
     async getProfile(userId) {
+        if (this.userProfileCache.has(userId)) {
+            console.debug(`Returning cached copy of ${userId}'s profile`)
+            return this.userProfileCache.get(userId);
+        }
+        console.debug(`Fetching fresh copy of ${userId}'s profile`)
         const data = await this.fetchJson(
             `${this.serverUrl}/r0/profile/${encodeURIComponent(
                 userId
@@ -126,6 +132,9 @@ class Client {
                 headers: { Authorization: `Bearer ${this.accessToken}` },
             }
         );
+        this.userProfileCache.set(userId, data);
+        return data;
+    }
         return data;
     }
 

--- a/src/Message.js
+++ b/src/Message.js
@@ -25,12 +25,21 @@ class Message extends React.Component {
             reputationScore: 0,
             hidden: false,
             uploadFile: null,
+            displayname: null,
         };
     }
 
-    componentDidMount() {
+    async componentDidMount() {
         if (!this.props.event) {
             return;
+        }
+        try {
+            const profile = await this.context.client.getProfile(this.props.event.sender);
+            this.setState({
+                displayname: profile.displayname,
+            });
+        } catch (ex) {
+            console.debug(`Failed to fetch profile for user ${this.props.event.sender}:`, ex);
         }
         this.context.reputation.trackScore(
             this.props.event,
@@ -43,7 +52,7 @@ class Message extends React.Component {
         );
     }
 
-    componentDidUpdate(oldProps) {
+    async componentDidUpdate(oldProps) {
         if (
             oldProps.event &&
             this.props.event &&
@@ -66,6 +75,15 @@ class Message extends React.Component {
                     });
                 }
             );
+            // Ensure we update the profile
+            try {
+                const profile = await this.context.client.getProfile(this.props.event.sender);
+                this.setState({
+                    displayname: profile.displayname,
+                });
+            } catch (ex) {
+                console.debug(`Failed to fetch profile for user ${this.props.event.sender}:`, ex);
+            }
         }
     }
 
@@ -214,8 +232,9 @@ class Message extends React.Component {
                     <div
                         className="MessageAuthor"
                         onClick={this.onAuthorClick.bind(this, event.sender)}
+                        title={event.sender}
                     >
-                        {event.sender}{" "}
+                        {this.state.displayname || event.sender}{" "}
                     </div>
                     {this.renderTime(event.origin_server_ts)}
                 </div>


### PR DESCRIPTION
This change changes the Message class to use a displayname where possible over the sender user_id of an event. This looks much cleaner, especially when handling bridged users.

The Client class now has a simple in memory cache to avoid repeated lookups.

![image](https://user-images.githubusercontent.com/2072976/103656098-1607d980-4f60-11eb-9602-1e4f2c2fd4c8.png)
