### PR TITLE
Support for displaying biographies in user timelines

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -124,6 +124,7 @@ class Client {
                 headers: { Authorization: `Bearer ${this.accessToken}` },
             }
         );
+        return data;
     }
 
     async getRoomState(roomId, stateType, stateKey) {

--- a/src/Client.js
+++ b/src/Client.js
@@ -124,6 +124,16 @@ class Client {
                 headers: { Authorization: `Bearer ${this.accessToken}` },
             }
         );
+    }
+
+    async getRoomState(roomId, stateType, stateKey) {
+        const data = await this.fetchJson(
+            `${this.serverUrl}/r0/rooms/${encodeURIComponent(roomId)}/state/${encodeURIComponent(stateType)}/${(stateKey && encodeURIComponent(stateKey)) || ''}`,
+            {
+                method: "GET",
+                headers: { Authorization: `Bearer ${this.accessToken}` },
+            }
+        );
         return data;
     }
 

--- a/src/TimelinePage.css
+++ b/src/TimelinePage.css
@@ -6,13 +6,6 @@
     margin-top: 16px;
 }
 
-.UserPageHeader{
-    background: #F7F7F7;
-    border-radius: 12px;
-    padding: 20px;
-    margin-bottom: 10px;
-}
-
 .UserPageBody{
     background: #F7F7F7;
     border-bottom-left-radius: 12px;

--- a/src/UserPage.css
+++ b/src/UserPage.css
@@ -7,17 +7,21 @@
     line-height: 18px;
     padding-bottom: 15px;
     font-family: Inter;
-}
-
-.UserPage{
-    margin-top: 16px;
-}
-
-.UserPageHeader{
     background: #F7F7F7;
     border-radius: 12px;
     padding: 20px;
     margin-bottom: 10px;
+}
+
+.UserProfile {
+    display: grid;
+    grid-template-columns: 1fr 10fr;
+    column-gap: 10px;
+    margin-bottom: 10px;
+}
+
+.UserPage{
+    margin-top: 16px;
 }
 
 .UserPageBody{
@@ -101,4 +105,3 @@
     align-items: center;
     margin-bottom: 8px;
 }
-

--- a/src/UserPage.js
+++ b/src/UserPage.js
@@ -21,6 +21,7 @@ class UserPage extends React.Component {
             isMe: props.userId === props.client.userId,
             roomId: null,
             userProfile: null,
+            userBiography: null,
         };
     }
 
@@ -55,7 +56,6 @@ class UserPage extends React.Component {
         try {
             roomId = await this.props.client.followUser(this.props.userId);
             this.loadProfile(); // don't block the UI by waiting for this
-
             this.setState({
                 timeline: [],
                 roomId: roomId,
@@ -91,8 +91,10 @@ class UserPage extends React.Component {
                     64
                 );
             }
+            const topicRes = await this.props.client.getRoomState(roomId, 'm.room.topic');
             this.setState({
                 userProfile,
+                userBiography: topicRes?.topic || '',
             });
         } catch (ex) {
             console.warn(
@@ -237,6 +239,11 @@ class UserPage extends React.Component {
                                 </div>
                             )}
                             <div className="userName">{this.props.userId}</div>
+                            { this.state.userBiography && (
+                                <div className="userBiography">
+                                    {this.state.userBiography}
+                                </div>  
+                            )}
                         </div>
                     </div>
                     {inputMessage}

--- a/src/UserPage.js
+++ b/src/UserPage.js
@@ -55,7 +55,7 @@ class UserPage extends React.Component {
         let roomId;
         try {
             roomId = await this.props.client.followUser(this.props.userId);
-            this.loadProfile(); // don't block the UI by waiting for this
+            this.loadProfile(roomId); // don't block the UI by waiting for this
             this.setState({
                 timeline: [],
                 roomId: roomId,
@@ -78,7 +78,7 @@ class UserPage extends React.Component {
         }
     }
 
-    async loadProfile() {
+    async loadProfile(roomId) {
         try {
             const userProfile = await this.props.client.getProfile(
                 this.props.userId


### PR DESCRIPTION
This change uses the `m.room.topic` state of a profile room as the biography for users. This is specifically for the bridge use case atm (there is no support for editing it). I'm not sure yet if the topic is the best place to store a bio, so happy to hear opinions on if we should have a dedicated state event for it?

![image](https://user-images.githubusercontent.com/2072976/103655939-e0fb8700-4f5f-11eb-820b-b851f5ac9177.png)
